### PR TITLE
Remove extraneous lit-html dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "dagre": "^0.8.5",
         "lit-element": "^2.4.0",
-        "lit-html": "^1.3.0",
         "roughjs": "^4.3.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "dagre": "^0.8.5",
     "lit-element": "^2.4.0",
-    "lit-html": "^1.3.0",
     "roughjs": "^4.3.1"
   },
   "devDependencies": {

--- a/src/event-steps.ts
+++ b/src/event-steps.ts
@@ -1,5 +1,4 @@
 import { LitElement, html, css, property, customElement } from "lit-element";
-import { classMap } from "lit-html/directives/class-map";
 
 import { EventDispatchingStep } from "./simulator.js";
 
@@ -84,7 +83,7 @@ export class EventSteps extends LitElement {
             `;
           }
 
-          return html`<li class=${classMap({ active: i === activeStep })}>
+          return html`<li class=${i === activeStep ? "active" : ""}>
             <button @click=${() => this.dispatchStepChange(i)}>
               <div class="counter">${i + 1}</div>
               <div class="description">${content}</div>


### PR DESCRIPTION
Skypack CDN does deliver a separate file to for `lit-html/directives/class-map`. Since it is actually used in a single place, it can be easily removed.