### PR TITLE
Fix conflict with declarative shadow DOM syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Alternatively for drop-in consumption this package can directly be loaded from [
 
 The visualized DOM tree is configured by passing a `<template>` element in the default slot. The content of the template tag is interpreted by the `<event-visualizer>` custom element to render the visual previous of the DOM tree and emulate event dispatching:
 
-- Shadow trees can be defined directly in HTML via the [declarative shadow DOM syntax](https://github.com/mfreed7/declarative-shadow-dom).
+- Shadow trees can be defined directly in HTML via the [declarative shadow DOM](https://github.com/mfreed7/declarative-shadow-dom) syntax with the difference difference that the `shadow-root` attribute is renamed to `data-shadow-root`.
 - The original event target is defined by adding a `target` attribute.
 - A label can be added to any element using the `id` attribute.
 - Restrictions:
@@ -68,7 +68,7 @@ The visualized DOM tree is configured by passing a `<template>` element in the d
 <event-visualizer label="Simple shadow tree">
   <template>
     <div id="a">
-      <template shadowroot="open">
+      <template data-shadowroot="open">
         <div id="b" target></div>
       </template>
       <div id="c">

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
     <event-visualizer label="Simple shadow tree" event-bubbles event-composed>
       <template>
         <div id="a">
-          <template shadowroot="open">
+          <template data-shadowroot="open">
             <div id="c">
               <div id="d" target></div>
             </div>
@@ -47,9 +47,9 @@
     >
       <template>
         <div id="a">
-          <template shadowroot="open">
+          <template data-shadowroot="open">
             <div id="c">
-              <template shadowroot="open">
+              <template data-shadowroot="open">
                 <div id="e" target></div>
               </template>
               <div id="d"></div>
@@ -63,7 +63,7 @@
     <event-visualizer label="Event dispatching from slotted content" event-bubbles event-composed>
       <template>
         <div id="a">
-          <template shadowroot="open">
+          <template data-shadowroot="open">
             <div id="c">
               <slot id="d"></slot>
               <div id="e"></div>
@@ -77,9 +77,9 @@
     <event-visualizer label="Event dispatching from closed shadow" event-bubbles event-composed>
       <template>
         <div id="a">
-          <template shadowroot="closed">
+          <template data-shadowroot="closed">
             <div id="c">
-              <template shadowroot="closed">
+              <template data-shadowroot="closed">
                 <div id="e" target></div>
               </template>
               <div id="d"></div>

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -43,11 +43,11 @@ const EVENT_NAME = "__TEST_EVENT__";
  * specification.
  */
 function applyDeclarativeShadowDom(template: HTMLTemplateElement): ShadowRoot {
-  const mode = template.getAttribute("shadowroot");
+  const mode = template.getAttribute("data-shadowroot");
 
   if (mode !== "open" && mode !== "closed") {
     throw new Error(
-      `Invalid shadowroot attribute value. Expected "open" or "closed" but received "${mode}"`
+      `Invalid data-shadowroot attribute value. Expected "open" or "closed" but received "${mode}"`
     );
   }
 
@@ -122,7 +122,7 @@ export function createDomTree(template: HTMLTemplateElement): DomTree {
 
     if (
       currentElement instanceof HTMLTemplateElement &&
-      currentElement.hasAttribute("shadowroot")
+      currentElement.hasAttribute("data-shadowroot")
     ) {
       const shadowRoot = applyDeclarativeShadowDom(currentElement);
       createShadowRootTreeNode({

--- a/src/event-steps.ts
+++ b/src/event-steps.ts
@@ -184,6 +184,7 @@ export class EventSteps extends LitElement {
     .step-controls {
       display: flex;
       justify-content: space-between;
+      gap: var(--spacing-medium);
       margin-bottom: var(--spacing-medium);
     }
 


### PR DESCRIPTION
This PR fixes an issue where the declarative DOM tree syntax breaks now that Chrome shipped declarative shadow DOM. I originally thought that the HTML parser would not convert the declarative shadow DOM syntax for elements that are contained in the template. It turned out that I was wrong. With the elements in the templates being converted as shadow trees, it breaks the visualization.

As a work around the `shadow-root` attribute is renamed to `data-shadow-root` which is a breaking change.

